### PR TITLE
Allow setting autotrack option

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.leadfeeder.com"
 documentation: "https://help.leadfeeder.com/en/articles/3727657-how-to-install-leadfeeder-tracker-using-google-tag-manager-and-the-leadfeeder-tracker-template"
 versions:
+  - sha: 5564454c9f4e00cda83e1797540fe1355aa8f5cf
+    changeNotes: Allow setting autotrack option
   - sha: c863155d34683736cec7585d877e0e8609609d4b
     changeNotes: Allow adding multiple trackers to one page
   - sha: 2f9615ae9424267dac74761c9b106e9c22a8c897

--- a/template.tpl
+++ b/template.tpl
@@ -43,7 +43,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "NON_EMPTY"
       }
     ],
-    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking\" target\u003d\"_blank\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e",
+    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking/script\" target\u003d\"_blank\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e",
     "alwaysInSummary": true
   },
   {

--- a/template.tpl
+++ b/template.tpl
@@ -60,8 +60,6 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
-const setInWindow = require('setInWindow');
-const callInWindow = require('callInWindow');
 const injectScript = require('injectScript');
 const createArgumentsQueue = require('createArgumentsQueue');
 const encodeUriComponent = require('encodeUriComponent');
@@ -69,9 +67,13 @@ const encodeUriComponent = require('encodeUriComponent');
 // Handle both the case when someone provides a raw tracker ID and the case when the tracker ID is prepended with 'v1_'.
 const versionlessTrackerId = data.lf_tracker_id.indexOf('v1_') == 0 ? data.lf_tracker_id.split('_')[1] : data.lf_tracker_id;
 
-createArgumentsQueue('ldfdr', 'ldfdr._q');
-callInWindow('ldfdr', 'cfg', 'enableAutoTracking', data.autotrack, versionlessTrackerId);
+// The following line creates a `ldfdr` function in `window`.
+// Once called the function appends arguments to `ldfdr._q` array.
+// Leadfeeder Tracker uses the arguments queue during initialization.
+const ldfdr = createArgumentsQueue('ldfdr', 'ldfdr._q');
+ldfdr('cfg', 'enableAutoTracking', data.autotrack, versionlessTrackerId);
 
+// Once the preconfiguration is done we can inject the tracker's code to a page:
 const lfTrackerSrc = 'https://sc.lfeeder.com/lftracker_v1_'+ encodeUriComponent(versionlessTrackerId) +'.js';
 injectScript(lfTrackerSrc, data.gtmOnSuccess, data.gtmOnFailure);
 

--- a/template.tpl
+++ b/template.tpl
@@ -211,52 +211,43 @@ ___TESTS___
 scenarios:
 - name: Main test
   code: |-
-    const mockData = {
-        "lf_tracker_id": "v1_w9k315xMkdlB0myP",
-        "autotrack": true
-      };
-
-
-    mock('injectScript', function(url, onSuccess, onFailure) {  assertThat(url).isEqualTo('https://sc.lfeeder.com/lftracker_v1_w9k315xMkdlB0myP.js');
+    mock('injectScript', function(url, onSuccess, onFailure) {  assertThat(url).isEqualTo('https://sc.lfeeder.com/lftracker_v1_abcd.js');
     });
 
     runCode(mockData);
     assertApi('injectScript').wasCalled();
 
-    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', true, 'w9k315xMkdlB0myP']]);
+    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', true, 'abcd']]);
 - name: Autotrack disabled test
   code: |-
-    const mockData = {
-      "lf_tracker_id": "v1_w9k315xMkdlB0myP",
-      "autotrack": false
-    };
+    mockData.autotrack = false;
 
     runCode(mockData);
     assertApi('injectScript').wasCalled();
 
-    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', false, 'w9k315xMkdlB0myP']]);
+    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', false, 'abcd']]);
 - name: v1 prefix missing test
   code: |-
-    const mockData = {
-        "lf_tracker_id": "w9k315xMkdlB0myP",
-        "autotrack": true
-      };
+    mockData.lf_tracker_id = 'abcd';
 
 
-    mock('injectScript', function(url, onSuccess, onFailure) {  assertThat(url).isEqualTo('https://sc.lfeeder.com/lftracker_v1_w9k315xMkdlB0myP.js');
+    mock('injectScript', function(url, onSuccess, onFailure) {  assertThat(url).isEqualTo('https://sc.lfeeder.com/lftracker_v1_abcd.js');
     });
 
     runCode(mockData);
     assertApi('injectScript').wasCalled();
 
-    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', true, 'w9k315xMkdlB0myP']]);
+    assertThat(copyFromWindow('ldfdr')._q).isEqualTo([['cfg', 'enableAutoTracking', true, 'abcd']]);
 setup: |-
-  const log = require('logToConsole');
   const copyFromWindow = require('copyFromWindow');
   const setInWindow = require('setInWindow');
 
   setInWindow('ldfdr', undefined, true);
 
+  const mockData = {
+    "lf_tracker_id": "v1_abcd",
+    "autotrack": true
+  };
 
 ___NOTES___
 

--- a/template.tpl
+++ b/template.tpl
@@ -43,7 +43,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "NON_EMPTY"
       }
     ],
-    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e"
+    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking\" target\u003d\"_blank\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e"
   },
   {
     "type": "CHECKBOX",

--- a/template.tpl
+++ b/template.tpl
@@ -189,7 +189,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": true
+                    "boolean": false
                   }
                 ]
               }

--- a/template.tpl
+++ b/template.tpl
@@ -43,7 +43,8 @@ ___TEMPLATE_PARAMETERS___
         "type": "NON_EMPTY"
       }
     ],
-    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking\" target\u003d\"_blank\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e"
+    "help": "You can find your Leadfeeder TrackerID in \u003ca href\u003d\"https://app.leadfeeder.com/l/settings/company/tracking\" target\u003d\"_blank\"\u003eLeadfeeder Tracker Settings\u003c/a\u003e",
+    "alwaysInSummary": true
   },
   {
     "type": "CHECKBOX",
@@ -51,7 +52,8 @@ ___TEMPLATE_PARAMETERS___
     "checkboxText": "Automatic tracking",
     "simpleValueType": true,
     "defaultValue": true,
-    "help": "When this checkbox is enabled the tracker will send a pageview event anytime the tag is included.\nDisabling this field might be useful e.g. when Leadfeeder tracker is used with Single Page Applications.\nYou can read more about SPA tracking \u003ca href\u003d\"https://help.leadfeeder.com/en/articles/4519005-customize-your-site-tracking-with-leadfeeder-javascript-api\" target\u003d\"_blank\"\u003eLeadfeeder Help Center\u003c/a\u003e"
+    "help": "When this checkbox is enabled the tracker will send a pageview event anytime the tag is included.\nDisabling this field might be useful e.g. when Leadfeeder tracker is used with Single Page Applications.\nYou can read more about SPA tracking \u003ca href\u003d\"https://help.leadfeeder.com/en/articles/4519005-customize-your-site-tracking-with-leadfeeder-javascript-api\" target\u003d\"_blank\"\u003eLeadfeeder Help Center\u003c/a\u003e",
+    "alwaysInSummary": true
   }
 ]
 

--- a/template.tpl
+++ b/template.tpl
@@ -58,7 +58,6 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
-const log = require('logToConsole');
 const setInWindow = require('setInWindow');
 const callInWindow = require('callInWindow');
 const injectScript = require('injectScript');
@@ -73,6 +72,7 @@ callInWindow('ldfdr', 'cfg', 'enableAutoTracking', data.autotrack, versionlessTr
 
 const lfTrackerSrc = 'https://sc.lfeeder.com/lftracker_v1_'+ encodeUriComponent(versionlessTrackerId) +'.js';
 injectScript(lfTrackerSrc, data.gtmOnSuccess, data.gtmOnFailure);
+
 
 ___WEB_PERMISSIONS___
 

--- a/template.tpl
+++ b/template.tpl
@@ -51,7 +51,7 @@ ___TEMPLATE_PARAMETERS___
     "checkboxText": "Automatic tracking",
     "simpleValueType": true,
     "defaultValue": true,
-    "help": "When this option is enabled the tracker will send a pageview event anytime the tag is included.\nDisable this option if you want to send the events yourself via the SDK."
+    "help": "When this checkbox is enabled the tracker will send a pageview event anytime the tag is included.\nDisabling this field might be useful e.g. when Leadfeeder tracker is used with Single Page Applications.\nYou can read more about SPA tracking \u003ca href\u003d\"https://help.leadfeeder.com/en/articles/4519005-customize-your-site-tracking-with-leadfeeder-javascript-api\" target\u003d\"_blank\"\u003eLeadfeeder Help Center\u003c/a\u003e"
   }
 ]
 


### PR DESCRIPTION
### Changes
The main point of this PR is to allow toggling automatic tracking on/off by using the new configuration mechanism introduced by @okulik.

Additional improvements include:
- Added a validation for `lf_tracker_id` config field - its presence will be required from now on
- Changed "Leadfeeder Tracker Settings" link to open in new browser tab
- Changed "Leadfeeder Tracker Settings" link to point to a correct tab in LF settings
- Wrapped `lf_tracker_id` with `encodeUriComponent` when building tracking script's URL. As suggested in https://github.com/Leadfeeder/leadfeeder-google-tag-manager-template/issues/1
- Added more unit tests
- Added support both for `tracker_id`s with and without `v1_` prefix

### Additional comments
- This change requires an additional `access_globals` privilege for `ldfdr._q` key.
- I'll post another PR with version bump once this is merged .

Demo:
https://www.loom.com/share/75f02ecd18894cb3a79cce773c7458e0

closes https://github.com/Leadfeeder/leadfeeder-google-tag-manager-template/issues/1