### PR TITLE
Mark autotrack field as deprecated.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -49,10 +49,10 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "CHECKBOX",
     "name": "autotrack",
-    "checkboxText": "Automatic tracking",
+    "checkboxText": "[Deprecated] Automatic tracking",
     "simpleValueType": true,
     "defaultValue": true,
-    "help": "When this checkbox is enabled the tracker will send a pageview event anytime the tag is included.\nDisabling this field might be useful e.g. when Leadfeeder tracker is used with Single Page Applications.\nYou can read more about SPA tracking \u003ca href\u003d\"https://help.leadfeeder.com/en/articles/4519005-customize-your-site-tracking-with-leadfeeder-javascript-api\" target\u003d\"_blank\"\u003eLeadfeeder Help Center\u003c/a\u003e",
+    "help": "When this checkbox is enabled the tracker will send a pageview event anytime the tag is included.\nThis field is deprecated: for tracking Single Page Applications contact Leadfeeder directly.",
     "alwaysInSummary": true
   },
   {


### PR DESCRIPTION
New clients should use the new auto tracking mode instead of autotrack field, and
in case they want to disable autotrack they should contact us directly
as we prefer having this option in our DB instead of GTM.

Tested:
* imported template without changes into my own GTM
* created tag from template
* change autotrack to false from default true
* modified template so that autotrack is marked as deprecated
* verified that autotrack is still false even with deprecation message